### PR TITLE
PHP 8.1 Fix BreadcrumbIterator.php

### DIFF
--- a/src/View/BreadcrumbIterator.php
+++ b/src/View/BreadcrumbIterator.php
@@ -15,8 +15,7 @@ class BreadcrumbIterator extends ArrayIterator
 		parent::__construct($array, $flags);
 	}
 	
-	#[\ReturnTypeWillChange]
-	public function current()
+	public function current(): mixed
 	{
 		return $this->collection->active = parent::current();
 	}


### PR DESCRIPTION
ArrayIterator fix for php 8.1 instead of suppressing the errors.

Tested on debian 11, CentOS 7/8 and Cloudlinux 7 with php 8.1.6 and php 8.1.5