### PR TITLE
Add support for shallow nested resources

### DIFF
--- a/src/Routing/ResourceBreadcrumbs.php
+++ b/src/Routing/ResourceBreadcrumbs.php
@@ -99,17 +99,23 @@ class ResourceBreadcrumbs
 	protected function getRouteNameForAction(string $action): string
 	{
 		$names = $this->options['names'] ?? [];
-		$action = $names[$action] ?? "{$this->name}.{$action}";
-		
+
+		if ($this->isShallow() && in_array($action, ['show', 'edit'])) {
+			$action = $this->getShallowName().'.'.$action;
+		} else {
+			$action = $names[$action] ?? "{$this->name}.{$action}";
+		}
+
 		return trim(Route::mergeWithLastGroup(['as' => $action])['as'], '.');
 	}
 	
 	protected function getParameterNamesForAction(string $action): array
 	{
 		$parameters = $this->getRouteGroupParameters();
-		
+		$name = $this->isShallow() ? $this->getShallowName() : $this->name;
+
 		if (in_array($action, ['show', 'edit'])) {
-			$parameters[] = $this->options['parameters'][$this->name] ?? Str::singular($this->name);
+			$parameters[] = $this->options['parameters'][$name] ?? Str::singular($name);
 		}
 		
 		return $parameters;
@@ -123,5 +129,15 @@ class ResourceBreadcrumbs
 		preg_match_all($pattern, $prefix, $matches);
 
 		return $matches[1] ?? [];
+	}
+
+	private function isShallow(): bool
+	{
+		return isset($this->options['shallow']) && $this->options['shallow'];
+	}
+
+	private function getShallowName(): string
+	{
+		return last(explode('.', $this->name));
 	}
 }


### PR DESCRIPTION
Hey! Just tried out this package and it seems great, but I run into a problem where shallow nested resources are not working correctly. I tried to fix this with limited amount of time and knowledge about this package, but seems like I got the tests to pass, so let me know if you think this is ok.

Basically if we have something like this (same as in the test) and we visit `notes/1/edit`, then it wouldn't display anything at all, because in the registry it's registered as `users.notes.edit` and not `notes.edit`, but the route when it is resolved has name of `notes.edit`.  So this change basically makes sure it is registered with shallow name. 

```
Route::resource('users', ResourceRoutesTestController::class)
    ->breadcrumbs([
        'index' => 'Users',
        'create' => 'New User',
        'edit' => 'Edit',
    ]);

  Route::resource('users.notes', NotesController::class)
    ->shallow()
    ->breadcrumbs(fn(ResourceBreadcrumbs $breadcrumbs) => $breadcrumbs
        ->show(fn(Note $note) => $note->note, 'users.index', fn(Note $note) => $note->user)
        ->edit('Edit', '.show', fn(Note $note) => $note->user)
    );
```

Let me know what you think 👍 