### PR TITLE
Make Gretel embrace Inertia v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
     "type": "library",
   "license": "MIT",
   "require": {
-    "illuminate/support": "^8|^9|^10|^11|12.x-dev|dev-master",
-    "illuminate/routing": "^8|^9|^10|^11|12.x-dev|dev-master",
-    "illuminate/view": "^8|^9|^10|^11|12.x-dev|dev-master",
-    "laravel/serializable-closure": "^1.0"
+    "illuminate/support": "^10|^11|12.x-dev|dev-master",
+    "illuminate/routing": "^10|^11|12.x-dev|dev-master",
+    "illuminate/view": "^10|^11|12.x-dev|dev-master",
+    "laravel/serializable-closure": "^1.0|^2.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^6.24|^7.10|^8|^9|9.x-dev|10.x-dev|dev-master",
+    "orchestra/testbench": "^8|^9|9.x-dev|10.x-dev|dev-master",
     "friendsofphp/php-cs-fixer": "^3.0",
     "mockery/mockery": "^1.3",
-    "phpunit/phpunit": "^9.5|^10.5"
+    "phpunit/phpunit": "^10.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/Support/GretelServiceProvider.php
+++ b/src/Support/GretelServiceProvider.php
@@ -137,8 +137,8 @@ class GretelServiceProvider extends ServiceProvider
 		$packages = $config->get('gretel.packages', []);
 		
 		if (Arr::get($packages, 'inertiajs/inertia-laravel') && class_exists(Inertia::class)) {
-			Inertia::share('breadcrumbs', static function(Request $request) {
-				if ($route = $request->route()) {
+			Inertia::share('breadcrumbs', static function() {
+				if ($route = request()->route()) {
 					return $route->breadcrumbs()->jsonSerialize();
 				}
 				return [];

--- a/src/Support/GretelServiceProvider.php
+++ b/src/Support/GretelServiceProvider.php
@@ -137,8 +137,8 @@ class GretelServiceProvider extends ServiceProvider
 		$packages = $config->get('gretel.packages', []);
 		
 		if (Arr::get($packages, 'inertiajs/inertia-laravel') && class_exists(Inertia::class)) {
-			Inertia::share('breadcrumbs', static function() {
-				if ($route = request()->route()) {
+			Inertia::share('breadcrumbs', static function(Request $request) {
+				if ($route = $request->route()) {
 					return $route->breadcrumbs()->jsonSerialize();
 				}
 				return [];


### PR DESCRIPTION
Current Gretel at school age of v1.8.0 does not like to play with Inertia v2. Let's tell her a fairy tale, where Inertia v2 plays Hänsel and they push the witch into the oven, so they can find their safe way back home following the bread crumbs.

... as it does not sound like https://github.com/inertiajs/inertia-laravel/pull/678 is going to get merged.