### PR TITLE
PHP 8.4 explicit nullable types

### DIFF
--- a/src/Macros.php
+++ b/src/Macros.php
@@ -40,7 +40,7 @@ class Macros
 		Route $route,
 		$title,
 		$parent = null,
-		Closure $relation = null
+		?Closure $relation = null
 	): Route {
 		$registry->withExceptionHandling(function() use ($registry, $route, $title, $parent, $relation) {
 			if (! $name = $route->getName()) {

--- a/src/View/Breadcrumb.php
+++ b/src/View/Breadcrumb.php
@@ -20,7 +20,7 @@ class Breadcrumb implements Arrayable, Jsonable, JsonSerializable
 		string $title,
 		string $url,
 		bool $is_current_page = false,
-		Breadcrumb $parent = null
+		?Breadcrumb $parent = null
 	) {
 		$this->title = $title;
 		$this->url = $url;

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -23,8 +23,8 @@ class Breadcrumbs extends Component
 		RequestBreadcrumbs $breadcrumbs,
 		Registry $registry,
 		Repository $config,
-		string $framework = null,
-		string $view = null,
+		?string $framework = null,
+		?string $view = null,
 		bool $jsonLd = false,
 		bool $rdfa = false
 	) {

--- a/tests/InlineBlade.php
+++ b/tests/InlineBlade.php
@@ -13,8 +13,8 @@ class InlineBlade extends View
 	public function __construct(
 		string $contents,
 		$data = [],
-		Factory $factory = null,
-		Filesystem $fs = null
+		?Factory $factory = null,
+		?Filesystem $fs = null
 	) {
 		$this->fs = $fs ?? new Filesystem();
 		


### PR DESCRIPTION
Fix such PHP 8.4 deprecations of implicit nullable types:

```
Glhd\Gretel\Macros::breadcrumb(): Implicitly marking parameter $relation as nullable is deprecated, the explicit nullable type must be used instead in glhd/gretel/src/Macros.php on line 38
```