### PR TITLE
Add support for nested resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,35 @@ Route::resource('users', UserController::class)
   ]);
 ```
 
+You can define breadcrumbs for nested resources. Parent resources will be passed
+to callables, otherwise is the same simple resource controllers.
+
+
+```php
+Route::resource('users.files', FilesController::class)
+  ->breadcrumbs(function(ResourceBreadcrumbs $breadcrumbs) {
+    $breadcrumbs
+      ->index('Files')
+      ->create('New File')
+      ->show(fn(User $user, File $file) => $file->name)
+      ->edit('Edit');
+  });
+```
+
+In addition you can set parent a parent resource route as parent route. Parent
+resource parameters are included in the route generation params.
+
+```php
+Route::resource('users.files', FilesController::class)
+  ->breadcrumbs(function(ResourceBreadcrumbs $breadcrumbs) {
+    $breadcrumbs
+      ->index('Files', 'users.show')
+      ->create('New File')
+      ->show(fn(User $user, File $file) => $file->name)
+      ->edit('Edit');
+  });
+```
+
 #### Vendor Routes
 
 Sometimes you want to register breadcrumbs for routes that are defined in 3rd-party packages.

--- a/src/Routing/ResourceBreadcrumbs.php
+++ b/src/Routing/ResourceBreadcrumbs.php
@@ -109,11 +109,15 @@ class ResourceBreadcrumbs
 	protected function getParameterNamesForAction(string $action): array
 	{
 		$parameters = $this->getRouteGroupParameters();
-		
-		if (in_array($action, ['show', 'edit'])) {
-			$parameters[] = $this->getResourceWildcard();
+		$nameParts = explode('.', $this->name);
+		$lastPart = end($nameParts);
+
+		foreach ($nameParts as $part) {
+			if ($lastPart !== $part || in_array($action, ['show', 'edit'])) {
+				$parameters[] = $this->getResourceWildcard($part);
+			}
 		}
-		
+
 		return $parameters;
 	}
 	
@@ -127,13 +131,13 @@ class ResourceBreadcrumbs
 		return $matches[1] ?? [];
 	}
 	
-	protected function getResourceWildcard(): string
+	protected function getResourceWildcard(string $value): string
 	{
 		return str_replace('-', '_', $this->getRawResourceWildcard());
 	}
 	
 	/** @see \Illuminate\Routing\ResourceRegistrar::getResourceWildcard() */
-	protected function getRawResourceWildcard(): string
+	protected function getRawResourceWildcard(string $value): string
 	{
 		$value = $this->name;
 		


### PR DESCRIPTION
Hello I am using the package in my last projects and loving it. The only issue I had this far is with nested resource support. There is also an issue for nested resources #18.

After some debugging I have come to the conclusion that even though parent resource params are passed to UrlResolver, they are filtered out because they are not included in parameter names generated for resource breadcrumbs.

This adds parent resource params in parameter names and adds some examples in the documentation examples.

Please let me know if this is something you would like to add, and provide further guidance for this pull request.